### PR TITLE
Add methods to resolve ambiguity with Base

### DIFF
--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -93,7 +93,7 @@ Base.://(x, y::HalfInteger) = twice(x)//twice(y)
 # Ambiguity resolution with Base
 Base.://(x::HalfInteger, y::Complex) = twice(x)//twice(y)
 Base.://(x::Complex, y::HalfInteger) = twice(x)//twice(y)
-Base.://(x::AbstractArray, y::HalfInteger) = twice(x)//twice(y)
+Base.://(x::AbstractArray, y::HalfInteger) = twice.(x) .// twice(y)
 
 Base.:^(x::Real, y::HalfInteger) = x^float(y)
 Base.:^(::Irrational{:ℯ}, x::HalfInteger) = exp(x)

--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -90,6 +90,11 @@ Base.://(x::HalfInteger, y::HalfInteger) = twice(x)//twice(y)
 Base.://(x::HalfInteger, y) = twice(x)//twice(y)
 Base.://(x, y::HalfInteger) = twice(x)//twice(y)
 
+# Ambiguity resolution with Base
+Base.://(x::HalfInteger, y::Complex) = twice(x)//twice(y)
+Base.://(x::Complex, y::HalfInteger) = twice(x)//twice(y)
+Base.://(x::AbstractArray, y::HalfInteger) = twice(x)//twice(y)
+
 Base.:^(x::Real, y::HalfInteger) = x^float(y)
 Base.:^(::Irrational{:ℯ}, x::HalfInteger) = exp(x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,9 @@ halfuinttypes = (:HalfUInt, :HalfUInt8, :HalfUInt16, :HalfUInt32, :HalfUInt64, :
 
 ==ₜ(x, y) = x === y
 ==ₜ(x::T, y::T) where T<:Union{BigInt,BigFloat,BigHalfInt,Rational{BigInt},Complex{BigInt},Complex{BigFloat},Complex{BigHalfInt},Complex{Rational{BigInt}}} = x == y
+==ₜ(x::AbstractArray, y::AbstractArray) = (x == y) && (typeof(x) == typeof(y))
+
+@test isempty(Test.detect_ambiguities(HalfIntegers, Base))
 
 @testset "Constructors" begin
     for T in (halfinttypes..., halfuinttypes..., :BigHalfInt)
@@ -671,6 +674,13 @@ end
             @test 2 // BigHalfInt(2) ==ₜ Rational{BigInt}(1//1)
             @test BigInt(2) // BigHalfInt(2) ==ₜ Rational{BigInt}(1//1)
             @test (4//3) // BigHalfInt(3/2) ==ₜ Rational{BigInt}(8//9)
+
+            # Extra tests for ambiguity resolution with Base
+            for T in (halfinttypes..., halfuinttypes..., BigHalfInt)
+                @eval @test [1]//$T(2) ==ₜ [1//$T(2)]
+                @eval @test Complex(2,0)//$T(2) ==ₜ Complex(2//$T(2),0//1)
+                @eval @test $T(2)//Complex(2,0) ==ₜ Complex($T(2)//2,0//1)
+            end
         end
 
         @testset "div/rem/mod" begin


### PR DESCRIPTION
Added methods to `//` to resolve ambiguity involving `Complex` numbers and `AbstractArray`s. Also added a test to ensure that ambiguities do not creep in.