### PR TITLE
Add methods and tests for onehalf

### DIFF
--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -366,6 +366,7 @@ julia> onehalf(HalfInt)
 """
 onehalf(x::Union{Number,Missing}) = onehalf(typeof(x))
 
+onehalf(T::Type{<:Number}) = T(onehalf(HalfInteger))
 onehalf(T::Type{<:HalfInteger}) = half(T, 1)
 onehalf(T::Type{<:AbstractFloat}) = T(0.5)
 @static if VERSION ≥ v"1.5.0-DEV.820"
@@ -374,7 +375,7 @@ onehalf(T::Type{<:AbstractFloat}) = T(0.5)
 else
     onehalf(T::Type{<:Rational}) = T(1, 2)
 end
-onehalf(::Type{Complex{T}}) where T = Complex(onehalf(T), zero(T))
+onehalf(::Type{Complex{T}}) where T = Complex{T}(onehalf(T), zero(T))
 onehalf(::Type{Missing}) = missing
 
 const HalfIntegerOrInteger = Union{HalfInteger, Integer}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -318,10 +318,13 @@ end
 end
 
 @testset "onehalf" begin
-    for T in (halfinttypes..., halfuinttypes..., :BigHalfInt, :Float16, :Float32, :Float64, :BigFloat,
-              :(Rational{Int}), :(Rational{UInt8}), :(Rational{BigInt}))
-        @eval @test onehalf($T) ==ₜ $T(1//2)
-        @eval @test onehalf(Complex{$T}) ==ₜ Complex{$T}(1//2, 0)
+    @test onehalf(Number) === onehalf(HalfInt)
+    @test onehalf(Complex) === onehalf(Complex{HalfInt})
+    for T in (:Real, :HalfInteger, halfinttypes..., halfuinttypes..., :BigHalfInt, :(Half{Integer}),
+              :AbstractFloat, :Float16, :Float32, :Float64, :BigFloat,
+              :Rational, :(Rational{Int}), :(Rational{UInt8}), :(Rational{BigInt}), :(Rational{Integer}))
+        @eval @test onehalf($T) ==ₜ $T(HalfInt(1/2))
+        @eval @test onehalf(Complex{$T}) ==ₜ Complex{$T}(HalfInt(1/2), 0)
     end
 end
 


### PR DESCRIPTION
This adds methods (and tests) for calling `onehalf` with abstract types, e.g. `onehalf(Real)`.