### PR TITLE
Add unsafeconvert

### DIFF
--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -506,4 +506,6 @@ const HalfUInt128 = Half{UInt128}
 Base.sinpi(x::BigHalfInt) = big(invoke(sinpi, Tuple{HalfInteger}, x))
 Base.cospi(x::BigHalfInt) = big(invoke(cospi, Tuple{HalfInteger}, x))
 
+unsafeconvert(::Type{T}, x::Half{T}) where {T<:Integer} = twice(x) >> 1
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ halfuinttypes = (:HalfUInt8, :HalfUInt16, :HalfUInt32, :HalfUInt64, :HalfUInt128
 ==ₜ(x::T, y::T) where T<:Union{BigInt,BigFloat,BigHalfInt,Rational{BigInt},Complex{BigInt},Complex{BigFloat},Complex{BigHalfInt},Complex{Rational{BigInt}}} = x == y
 ==ₜ(x::AbstractArray, y::AbstractArray) = (x == y) && (typeof(x) == typeof(y))
 
-@test isempty(Test.detect_ambiguities(HalfIntegers, Base))
+@test isempty(Test.detect_ambiguities(HalfIntegers, Base, Core))
 
 @testset "Aliases" begin
     @test HalfInt === Half{Int}
@@ -148,6 +148,12 @@ end
         for T in (inttypes..., uinttypes..., :BigInt)
             @eval @test Rational(Half{$T}(11/2)) ==ₜ Rational{$T}(11//2)
             @eval @test Rational(Half{$T}(5)) ==ₜ Rational{$T}(5//1)
+        end
+
+        @testset "unsafe" begin
+            for T in (inttypes..., uinttypes..., :BigInt)
+                @eval @test HalfIntegers.unsafeconvert($T,one(Half{$T})) ==ₜ one($T)
+            end
         end
     end
 


### PR DESCRIPTION
This PR adds an extra function `unsafeconvert` to convert from `HalfInteger` to `Integer` without checking if such a conversion is valid. This is useful in scenarios where the number is known to be an `Integer` wrapped in a `HalfInteger`.

```julia
julia> @btime Int(HalfInt(n)) setup=(n=rand(1:1))
  7.990 ns (0 allocations: 0 bytes)
1

julia> @btime HalfIntegers.unsafeconvert(Int,HalfInt(n)) setup=(n=rand(1:1))
  2.673 ns (0 allocations: 0 bytes)
1
```

The performance gain would help in tight loops.

Additionally there's an extra ambiguity test with `Core` that's added to make the condition more stringent. As of now this passes without any issues, but it might help in future development.