### PR TITLE
Align HalfIntegers at division slash when printing array columns

### DIFF
--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -155,6 +155,12 @@ Base.isinteger(x::HalfInteger) = iseven(twice(x))
     Base.ispow2(x::HalfInteger) = ispow2(twice(x))
 end
 
+function Base.alignment(io::IO, x::HalfInteger)
+    s = sprint(show, x, context=io, sizehint=0)
+    m = match(r"^(.*?)/2$", s)
+    m === nothing ? (length(s), 0) : (length(m.captures[1]), 2)
+end
+
 Base.show(io::IO, x::HalfInteger) =
     isinteger(x) ? print(io, twice(x) >> 1) : print(io, twice(x), "/2")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1616,16 +1616,22 @@ end
     end
 end
 
-@testset "string" begin
+@testset "Printing" begin
     for T in (halfinttypes..., :BigHalfInt)
-        @eval @test string($T(3/2)) === "3/2"
-        @eval @test string($T(5)) === "5"
-        @eval @test string($T(-3/2)) === "-3/2"
-        @eval @test string($T(-5)) === "-5"
+        @eval @test Base.alignment(stdout, $T(3/2))   === (1,2)
+        @eval @test Base.alignment(stdout, $T(15))    === (2,0)
+        @eval @test Base.alignment(stdout, $T(-11/2)) === (3,2)
+        @eval @test Base.alignment(stdout, $T(-10))   === (3,0)
+        @eval @test sprint(show, $T(3/2))   === "3/2"
+        @eval @test sprint(show, $T(15))    === "15"
+        @eval @test sprint(show, $T(-11/2)) === "-11/2"
+        @eval @test sprint(show, $T(-10))   === "-10"
     end
     for T in halfuinttypes
-        @eval @test string($T(3/2)) === "3/2"
-        @eval @test string($T(5)) === "5"
+        @eval @test Base.alignment(stdout, $T(3/2)) === (1,2)
+        @eval @test Base.alignment(stdout, $T(15))  === (2,0)
+        @eval @test sprint(show, $T(3/2)) === "3/2"
+        @eval @test sprint(show, $T(15))  === "15"
     end
 end
 


### PR DESCRIPTION
Before:
```julia
julia> [3:HalfInt(1/2):7;]
9-element Array{Half{Int64},1}:
    3
  7/2
    4
  9/2
    5
 11/2
    6
 13/2
    7
```

After:
```julia
julia> [3:HalfInt(1/2):7;]
9-element Array{Half{Int64},1}:
  3
  7/2
  4
  9/2
  5
 11/2
  6
 13/2
  7
```
I’m not actually sure which one looks better, so I’ll leave this open for now.