### PR TITLE
add specific Half constructor for Rational

### DIFF
--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -521,6 +521,16 @@ struct Half{T<:Integer} <: HalfInteger
 end
 Half{T}(x::Real) where T<:Integer = half(Half{T}, twice(T,x))
 Half{T}(x::Half{T}) where T<:Integer = x
+function Half{T}(x::Rational) where T<:Integer
+    if x.den == one(x.den)
+        tx = twice(T, x.num)
+    elseif x.den == one(x.den) + one(x.den)
+        tx = convert(T, x.num)
+    else
+        tx = twice(T, x)
+    end
+    return half(Half{T}, tx)
+end
 
 half(::Type{Half{T}}, x::Number) where T<:Integer = Half{T}(Val{:inner}(), x)
 

--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -522,9 +522,9 @@ end
 Half{T}(x::Real) where T<:Integer = half(Half{T}, twice(T,x))
 Half{T}(x::Half{T}) where T<:Integer = x
 function Half{T}(x::Rational) where T<:Integer
-    if x.den == one(x.den)
+    if x.den == 1
         tx = twice(T, x.num)
-    elseif x.den == one(x.den) + one(x.den)
+    elseif x.den == 2
         tx = convert(T, x.num)
     else
         tx = twice(T, x)


### PR DESCRIPTION
When converting a `x::Rational` to a `HalfInteger`, it goes via the generic `Half` constructor for `x::Number`, which calls `twice(T, x)` and thus ends up calling `x + x`. Addition of `Rational`s involves using `div` and `gcd`, and these were showing up in my profile experiments with WignerSymbols.jl.

When converting a `x::Rational` to a `HalfInteger`, it probably has `x.den == 1` or `x.den == 2`, and these cases can be dealt with much more efficiently. 