### PR TITLE
Add support for SaferIntegers v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* ![Maintenance](https://img.shields.io/badge/-maintenance-grey) Compatibility with SaferIntegers v3. ([#40](https://github.com/sostock/HalfIntegers.jl/pull/40))
+
 ## v1.4.0
 
 * ![Feature](https://img.shields.io/badge/-feature-green) Checked arithmetic functions (`Base.checked_add` etc.) now accept `HalfInteger` arguments. A `HalfIntegers.checked_twice` is added as well. ([#38](https://github.com/sostock/HalfIntegers.jl/pull/38))

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Sebastian Stock"]
 version = "1.4.0"
 
 [compat]
-SaferIntegers = "2.2.1"
+SaferIntegers = "2.2.1, 3.0.2"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
When using SaferIntegers v3, at least SaferIntegers 3.0.2 is required, because previous 3.0.x versions include method ambiguities that make the tests fail.