### PR TITLE
Add `Base.hastypemax` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* ![Bugfix](https://img.shields.io/badge/-bugfix-purple) Added specialized `Base.hastypemax` method because the generic fallback doesn’t work correctly for `BigHalfInt`. ([#42](https://github.com/sostock/HalfIntegers.jl/pull/42))
+
 ## v1.4.1
 
 * ![Maintenance](https://img.shields.io/badge/-maintenance-grey) Compatibility with SaferIntegers v3. ([#40](https://github.com/sostock/HalfIntegers.jl/pull/40))

--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -646,6 +646,7 @@ function Base.tryparse(::Type{Half{T}}, s::AbstractString) where T<:Integer
     return isempty(matched.captures[2]) ? Half{T}(num) : half(num)
 end
 
+Base.hastypemax(::Type{Half{T}}) where T<:Integer = Base.hastypemax(T)
 Base.typemax(::Type{Half{T}}) where T<:Integer = half(typemax(T))
 Base.typemin(::Type{Half{T}}) where T<:Integer = half(typemin(T))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -413,7 +413,9 @@ end
         for T in (inttypes..., uinttypes...)
             @eval @test typemin(Half{$T}) === half(Half{$T}, typemin($T))
             @eval @test typemax(Half{$T}) === half(Half{$T}, typemax($T))
+            @eval @test Base.hastypemax(Half{$T})
         end
+        @test !Base.hastypemax(BigHalfInt)
     end
 
     @testset "one/zero/isone/iszero" begin


### PR DESCRIPTION
Because the generic fallback returns the wrong result for `BigHalfInt`.