### PR TITLE
change promotion in rational conversion

### DIFF
--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -58,7 +58,7 @@ HalfInteger(x::BigFloat) = BigHalfInt(x)
         if isinteger(x)
             Base.unsafe_rational(T, tx >> 1, one(tx))
         else
-            Base.unsafe_rational(T, promote(tx, T(2))...)
+            Base.unsafe_rational(T, tx, twice(one(tx)))
         end
     end
 else

--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -50,7 +50,7 @@ HalfInteger(x::BigFloat) = BigHalfInt(x)
         if isinteger(x)
             Base.unsafe_rational(tx >> 1, one(tx))
         else
-            Base.unsafe_rational(tx, oftype(tx, 2))
+            Base.unsafe_rational(tx, twice(one(tx)))
         end
     end
     function (::Type{Rational{T}})(x::HalfInteger) where T
@@ -62,7 +62,7 @@ HalfInteger(x::BigFloat) = BigHalfInt(x)
         end
     end
 else
-    (T::Type{<:Rational})(x::HalfInteger) = (tx=twice(x); T(tx,oftype(tx,2)))
+    (T::Type{<:Rational})(x::HalfInteger) = (tx=twice(x); T(tx,twice(one(tx))))
 end
 
 Base.ArithmeticStyle(::Type{<:HalfInteger}) = Base.ArithmeticWraps()

--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -58,7 +58,7 @@ HalfInteger(x::BigFloat) = BigHalfInt(x)
         if isinteger(x)
             Base.unsafe_rational(T, tx >> 1, one(tx))
         else
-            Base.unsafe_rational(T, tx, oftype(tx,2))
+            Base.unsafe_rational(T, promote(tx, T(2))...)
         end
     end
 else

--- a/test/customtypes.jl
+++ b/test/customtypes.jl
@@ -9,6 +9,20 @@ MyHalfInt(x::MyHalfInt) = x
 HalfIntegers.half(::Type{MyHalfInt}, x) = MyHalfInt(half(HalfInt, x))
 HalfIntegers.twice(x::MyHalfInt) = twice(x.val)
 
+struct One <: Integer end
+Base.promote_type(::Type{One}, ::Type{One}) = Int
+Base.promote_rule(::Type{One}, ::Type{T}) where {T<:Number} = promote_type(Int, T)
+Base.convert(::Type{One}, x::Integer) = isone(x) ? One() : error("can't convert $x to One")
+Base.iszero(::One) = false
+Base.isone(::One) = true
+Base.Int(::One) = oneunit(Int)
+Base.oneunit(::One) = One()
+Base.one(::One) = one(Int)
+Base.zero(::One) = false
+Base.:(*)(y::One, ::One) = y
+Base.:(*)(::One, y::Integer) = y
+Base.:(*)(y::Integer, ::One) = y
+
 @testset "Custom types" begin
     @testset "Construction" begin
         @test MyHalfInt(2.5) isa MyHalfInt
@@ -35,6 +49,9 @@ HalfIntegers.twice(x::MyHalfInt) = twice(x.val)
         @test_throws InexactError Integer(MyHalfInt(3/2))
         @test_throws InexactError Int(MyHalfInt(3/2))
         @test_throws InexactError UInt(MyHalfInt(-1))
+
+        @test Rational(half(One())) == 1//2
+        @test Rational{Int}(half(One())) == 1//2
     end
 
     @testset "Properties" begin

--- a/test/customtypes.jl
+++ b/test/customtypes.jl
@@ -10,18 +10,11 @@ HalfIntegers.half(::Type{MyHalfInt}, x) = MyHalfInt(half(HalfInt, x))
 HalfIntegers.twice(x::MyHalfInt) = twice(x.val)
 
 struct One <: Integer end
-Base.promote_type(::Type{One}, ::Type{One}) = Int
-Base.promote_rule(::Type{One}, ::Type{T}) where {T<:Number} = promote_type(Int, T)
-Base.convert(::Type{One}, x::Integer) = isone(x) ? One() : error("can't convert $x to One")
-Base.iszero(::One) = false
-Base.isone(::One) = true
-Base.Int(::One) = oneunit(Int)
-Base.oneunit(::One) = One()
-Base.one(::One) = one(Int)
-Base.zero(::One) = false
-Base.:(*)(y::One, ::One) = y
-Base.:(*)(::One, y::Integer) = y
-Base.:(*)(y::Integer, ::One) = y
+Base.promote_rule(::Type{One}, ::Type{T}) where {T<:Number} = promote_type(Bool, T)
+Base.Int(::One) = 1
+Base.iseven(::One) = false
+Base.one(::One) = One()
+Base.:+(x::One, y::One) = 2
 
 @testset "Custom types" begin
     @testset "Construction" begin


### PR DESCRIPTION
This lets one use an odd integer type as the numerator, which can't store `2`. After this, one may use https://github.com/jishnub/OddEvenIntegers.jl to obtain
```julia
julia> Rational{Int}(half(Odd(1)))
1//2
```
This errors on master at present