### PR TITLE
convert instead of constructor in twice

### DIFF
--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -444,8 +444,8 @@ julia> twice(Complex{BigInt}, HalfInt(5/2) + HalfInt(3)*im)
 5 + 6im
 ```
 """
-twice(T::Type{<:Integer}, x::Number) = T(twice(x))
-twice(T::Type{<:Integer}, x::Integer) = twice(T(x)) # convert to T first to reduce probability of overflow
+twice(T::Type{<:Integer}, x::Number) = convert(T, twice(x))::T
+twice(T::Type{<:Integer}, x::Integer) = twice(convert(T, x)::T) # convert to T first to reduce probability of overflow
 twice(::Type{Complex{T}}, x::Number) where T<:Integer = Complex(twice(T,real(x)), twice(T,imag(x)))
 
 function twice(T::Type{<:Integer}, x::Rational)

--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -40,9 +40,9 @@ HalfInteger(x::HalfInteger) = x
 HalfInteger(x::Rational{T}) where T = Half{T}(x)
 HalfInteger(x::BigFloat) = BigHalfInt(x)
 
-(T::Type{<:AbstractFloat})(x::HalfInteger) = T(float(x))
+(T::Type{<:AbstractFloat})(x::HalfInteger) = convert(T, float(x))
 (T::Type{<:Integer})(x::HalfInteger) =
-    isinteger(x) ? T(twice(x) >> 1) : throw(InexactError(Symbol(T), T, x))
+    isinteger(x) ? convert(T, twice(x) >> 1) : throw(InexactError(Symbol(T), T, x))
 (::Type{Bool})(x::HalfInteger) = invoke(Bool, Tuple{Real}, x)
 @static if VERSION ≥ v"1.5.0-DEV.820"
     function (::Type{Rational})(x::HalfInteger)
@@ -159,8 +159,8 @@ Base.floor(T::Type{<:Integer}, x::HalfInteger) = round(T, x, RoundDown)
 Base.trunc(T::Type{<:Integer}, x::HalfInteger) = round(T, x, RoundToZero)
 
 Base.round(T::Type{<:Integer}, x::HalfInteger, r::RoundingMode=RoundNearest) =
-    T(twice(round(x, r)) >> 1)
-Base.round(T::Type{<:Integer}, x::HalfInteger, ::typeof(RoundDown)) = T(twice(x) >> 1)
+    convert(T, twice(round(x, r)) >> 1)
+Base.round(T::Type{<:Integer}, x::HalfInteger, ::typeof(RoundDown)) = convert(T, twice(x) >> 1)
 
 Base.round(x::HalfInteger, ::typeof(RoundNearest)) =
     isinteger(x)             ? +x           :
@@ -245,11 +245,11 @@ function coschalf(x::Integer)
     if xm4 == 0
         2*x⁻¹
     elseif xm4 == 1
-        (-4/T(π))*x⁻¹*x⁻¹
+        (-4/convert(T, π))*x⁻¹*x⁻¹
     elseif xm4 == 2
         -2*x⁻¹
     else
-        (4/T(π))*x⁻¹*x⁻¹
+        (4/convert(T, π))*x⁻¹*x⁻¹
     end
 end
 
@@ -519,9 +519,9 @@ julia> onehalf(HalfInt)
 """
 onehalf(x::Union{Number,Missing}) = onehalf(typeof(x))
 
-onehalf(T::Type{<:Number}) = T(onehalf(HalfInteger))
+onehalf(T::Type{<:Number}) = convert(T, onehalf(HalfInteger))
 onehalf(T::Type{<:HalfInteger}) = half(T, 1)
-onehalf(T::Type{<:AbstractFloat}) = T(0.5)
+onehalf(T::Type{<:AbstractFloat}) = convert(T, 0.5)
 @static if VERSION ≥ v"1.5.0-DEV.820"
     onehalf(::Type{Rational}) = Base.unsafe_rational(1, 2)
     onehalf(::Type{Rational{T}}) where T = Base.unsafe_rational(T, 1, 2)

--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -668,4 +668,6 @@ const HalfUInt128 = Half{UInt128}
 
 Base.float(::Type{BigHalfInt}) = BigFloat
 
+Base.one(::Type{Half{T}}) where T = half(twice(one(T)))
+
 end # module

--- a/test/customtypes.jl
+++ b/test/customtypes.jl
@@ -17,6 +17,14 @@ Base.one(::One) = One()
 Base.sign(::One) = One()
 Base.:+(x::One, y::One) = 2
 
+struct Two <: Integer end
+Base.promote_type(::Type{Two}, ::Type{Two}) = Int
+Base.promote_rule(::Type{Two}, ::Type{T}) where {T<:Number} = promote_type(Bool, T)
+Base.Int(::Two) = 2
+HalfIntegers.twice(::Type{Two}, x::Int) = isone(x) ? Two() : error("can't evaluate twice(Two, $x)")
+Base.:(>>)(::Two, n::UInt64) = 2 >> n # needed for displaying the result
+Base.convert(::Type{Two}, x::Int) = isone(half(x)) ? Two() : error("can't convert $x to Two")
+
 @testset "Custom types" begin
     @testset "Construction" begin
         @test MyHalfInt(2.5) isa MyHalfInt
@@ -50,6 +58,12 @@ Base.:+(x::One, y::One) = 2
         @test @inferred(denominator(half(One()))) == 2
         @test @inferred(Rational(half(One()))) == 1//2
         @test @inferred(Rational{Int}(half(One()))) == 1//2
+
+        one_halftwo = @inferred(one(half(Two())))
+        @test isone(one_halftwo)
+        one_halftwo_typed = @inferred(oneunit(half(Two())))
+        @test isone(one_halftwo_typed)
+        @test typeof(one_halftwo_typed) == typeof(half(Two()))
     end
 
     @testset "Properties" begin

--- a/test/customtypes.jl
+++ b/test/customtypes.jl
@@ -16,14 +16,7 @@ Base.iseven(::One) = false
 Base.one(::One) = One()
 Base.sign(::One) = One()
 Base.:+(x::One, y::One) = 2
-
-struct Two <: Integer end
-Base.promote_type(::Type{Two}, ::Type{Two}) = Int
-Base.promote_rule(::Type{Two}, ::Type{T}) where {T<:Number} = promote_type(Bool, T)
-Base.Int(::Two) = 2
-HalfIntegers.twice(::Type{Two}, x::Int) = isone(x) ? Two() : error("can't evaluate twice(Two, $x)")
-Base.:(>>)(::Two, n::UInt64) = 2 >> n # needed for displaying the result
-Base.convert(::Type{Two}, x::Int) = isone(half(x)) ? Two() : error("can't convert $x to Two")
+Base.convert(::Type{One}, x::Int) = x == 1 ? One() : error("can't convert $x to One")
 
 @testset "Custom types" begin
     @testset "Construction" begin
@@ -59,11 +52,8 @@ Base.convert(::Type{Two}, x::Int) = isone(half(x)) ? Two() : error("can't conver
         @test @inferred(Rational(half(One()))) == 1//2
         @test @inferred(Rational{Int}(half(One()))) == 1//2
 
-        one_halftwo = @inferred(one(half(Two())))
-        @test isone(one_halftwo)
-        one_halftwo_typed = @inferred(oneunit(half(Two())))
-        @test isone(one_halftwo_typed)
-        @test typeof(one_halftwo_typed) == typeof(half(Two()))
+        @test Half{One}(half(One())) === half(One())
+        @test Half{One}(half(1)) === half(One())
     end
 
     @testset "Properties" begin

--- a/test/customtypes.jl
+++ b/test/customtypes.jl
@@ -54,6 +54,9 @@ Base.convert(::Type{One}, x::Int) = x == 1 ? One() : error("can't convert $x to 
 
         @test Half{One}(half(One())) === half(One())
         @test Half{One}(half(1)) === half(One())
+
+        @test one(half(One())) == 1
+        @test one(half(One())) * half(One()) == half(One())
     end
 
     @testset "Properties" begin


### PR DESCRIPTION
Since the intention is to convert the type of the argument, it's better to use `convert(T, x)` instead of the constructor `T(x)`, as the two might mean different things, and in certain scenarios, such as the special numbers `One` and `Two`, the latter might not be meaningful even though the former is.