### PR TITLE
Add `ishalfodd` function

### DIFF
--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -589,8 +589,9 @@ ishalfoddinteger(::Missing) = missing
 if VERSION ≥ v"1.7"
     _isodd(x) = isodd(x)
 else
-    _isodd(x) = isodd(x)
-    _isodd(x::AbstractFloat) = isinteger(x) && abs(x) ≤ maxintfloat(x) && isodd(Integer(x))
+    _isodd(x::Real) = isodd(x)
+    _isodd(n::Number) = isreal(n) && _isodd(real(n))
+    _isodd(x::AbstractFloat) = isinteger(x) && abs(x) ≤ maxintfloat(x) && _isodd(Integer(x))
 end
 
 @static if VERSION ≥ v"1.7.0-DEV.263"

--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -583,7 +583,6 @@ false
 ishalfoddinteger(x::Number) = _isodd(twice(x))
 ishalfoddinteger(x::Rational) = denominator(x) == 2
 ishalfoddinteger(::Integer) = false
-ishalfoddinteger(::AbstractIrrational) = false
 ishalfoddinteger(::Missing) = missing
 
 if VERSION ≥ v"1.7"

--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -580,7 +580,7 @@ julia> ishalfoddinteger(1//3)
 false
 ```
 """
-ishalfoddinteger(x) = _isodd(twice(x))
+ishalfoddinteger(x::Number) = _isodd(twice(x))
 ishalfoddinteger(x::Rational) = denominator(x) == 2
 ishalfoddinteger(::Integer) = false
 ishalfoddinteger(::AbstractIrrational) = false

--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -23,7 +23,7 @@ export
     # Functions
     half,
     ishalfinteger,
-    ishalfoddinteger,
+    ishalfodd,
     onehalf,
     twice
 
@@ -563,27 +563,27 @@ ishalfinteger(::AbstractIrrational) = false
 ishalfinteger(::Missing) = missing
 
 """
-    ishalfoddinteger(x)
+    ishalfodd(x)
 
 Test whether `x` is numerically equal to some half-odd-integer.
 
 # Examples
 
 ```jldoctest
-julia> ishalfoddinteger(3.5)
+julia> ishalfodd(3.5)
 true
 
-julia> ishalfoddinteger(2)
+julia> ishalfodd(2)
 false
 
-julia> ishalfoddinteger(1//3)
+julia> ishalfodd(1//3)
 false
 ```
 """
-ishalfoddinteger(x::Number) = _isodd(twice(x))
-ishalfoddinteger(x::Rational) = denominator(x) == 2
-ishalfoddinteger(::Integer) = false
-ishalfoddinteger(::Missing) = missing
+ishalfodd(x::Number) = _isodd(twice(x))
+ishalfodd(x::Rational) = denominator(x) == 2
+ishalfodd(::Integer) = false
+ishalfodd(::Missing) = missing
 
 if VERSION ≥ v"1.7"
     _isodd(x) = isodd(x)

--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -580,11 +580,18 @@ julia> ishalfoddinteger(1//3)
 false
 ```
 """
-ishalfoddinteger(x) = isodd(twice(x))
+ishalfoddinteger(x) = _isodd(twice(x))
 ishalfoddinteger(x::Rational) = denominator(x) == 2
 ishalfoddinteger(::Integer) = false
 ishalfoddinteger(::AbstractIrrational) = false
 ishalfoddinteger(::Missing) = missing
+
+if VERSION ≥ v"1.7"
+    _isodd(x) = isodd(x)
+else
+    _isodd(x) = isodd(x)
+    _isodd(x::AbstractFloat) = isinteger(x) && abs(x) ≤ maxintfloat(x) && isodd(Integer(x))
+end
 
 @static if VERSION ≥ v"1.7.0-DEV.263"
     Base.range_start_stop_length(start::T, stop::T, len::Integer) where T<:HalfInteger =

--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -23,6 +23,7 @@ export
     # Functions
     half,
     ishalfinteger,
+    ishalfoddinteger,
     onehalf,
     twice
 
@@ -560,6 +561,30 @@ ishalfinteger(x::Rational) = (denominator(x) == 1) | (denominator(x) == 2)
 ishalfinteger(::HalfIntegerOrInteger) = true
 ishalfinteger(::AbstractIrrational) = false
 ishalfinteger(::Missing) = missing
+
+"""
+    ishalfoddinteger(x)
+
+Test whether `x` is numerically equal to some half-odd-integer.
+
+# Examples
+
+```jldoctest
+julia> ishalfoddinteger(3.5)
+true
+
+julia> ishalfoddinteger(2)
+false
+
+julia> ishalfoddinteger(1//3)
+false
+```
+"""
+ishalfoddinteger(x) = isodd(twice(x))
+ishalfoddinteger(x::Rational) = denominator(x) == 2
+ishalfoddinteger(::Integer) = false
+ishalfoddinteger(::AbstractIrrational) = false
+ishalfoddinteger(::Missing) = missing
 
 @static if VERSION ≥ v"1.7.0-DEV.263"
     Base.range_start_stop_length(start::T, stop::T, len::Integer) where T<:HalfInteger =

--- a/test/customtypes.jl
+++ b/test/customtypes.jl
@@ -62,7 +62,7 @@ Base.convert(::Type{One}, x::Int) = x == 1 ? One() : error("can't convert $x to 
     @testset "Properties" begin
         @test isfinite(MyHalfInt(2))
         @test ishalfinteger(MyHalfInt(3/2))
-        @test ishalfoddinteger(MyHalfInt(3/2))
+        @test ishalfodd(MyHalfInt(3/2))
         @test isinteger(MyHalfInt(3))
         @test !isinteger(MyHalfInt(3/2))
         @test iszero(MyHalfInt(0))

--- a/test/customtypes.jl
+++ b/test/customtypes.jl
@@ -62,6 +62,7 @@ Base.convert(::Type{One}, x::Int) = x == 1 ? One() : error("can't convert $x to 
     @testset "Properties" begin
         @test isfinite(MyHalfInt(2))
         @test ishalfinteger(MyHalfInt(3/2))
+        @test ishalfoddinteger(MyHalfInt(3/2))
         @test isinteger(MyHalfInt(3))
         @test !isinteger(MyHalfInt(3/2))
         @test iszero(MyHalfInt(0))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -374,6 +374,24 @@ end
         @test !ishalfinteger(im)
     end
 
+    @testset "ishalfoddinteger" begin
+        for T in (halfinttypes..., halfuinttypes..., :BigHalfInt)
+            @eval @test !ishalfoddinteger($T(3))
+            @eval @test ishalfoddinteger($T(5/2))
+        end
+        @test !ishalfoddinteger(5)
+        @test !ishalfoddinteger(big(-5))
+        @test ishalfoddinteger(5//2)
+        @test ishalfoddinteger(-3//2)
+        @test !ishalfoddinteger(4//3)
+        @test !ishalfoddinteger(2.0)
+        @test ishalfoddinteger(-7.5)
+        @test !ishalfoddinteger(2.3)
+        @test !ishalfoddinteger(π)
+        @test !ishalfoddinteger(ℯ)
+        @test !ishalfoddinteger(im)
+    end
+
     @testset "isinteger" begin
         for T in (halfinttypes..., :BigHalfInt)
             @eval @test isinteger($T(3))
@@ -1690,6 +1708,7 @@ end
     @test onehalf(missing) === onehalf(Missing) === missing
 
     @test ishalfinteger(missing) === missing
+    @test ishalfoddinteger(missing) === missing
 end
 
 include("ranges.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -374,22 +374,22 @@ end
         @test !ishalfinteger(im)
     end
 
-    @testset "ishalfoddinteger" begin
+    @testset "ishalfodd" begin
         for T in (halfinttypes..., halfuinttypes..., :BigHalfInt)
-            @eval @test !ishalfoddinteger($T(3))
-            @eval @test ishalfoddinteger($T(5/2))
+            @eval @test !ishalfodd($T(3))
+            @eval @test ishalfodd($T(5/2))
         end
-        @test !ishalfoddinteger(5)
-        @test !ishalfoddinteger(big(-5))
-        @test ishalfoddinteger(5//2)
-        @test ishalfoddinteger(-3//2)
-        @test !ishalfoddinteger(4//3)
-        @test !ishalfoddinteger(2.0)
-        @test ishalfoddinteger(-7.5)
-        @test !ishalfoddinteger(2.3)
-        @test !ishalfoddinteger(π)
-        @test !ishalfoddinteger(ℯ)
-        @test !ishalfoddinteger(im)
+        @test !ishalfodd(5)
+        @test !ishalfodd(big(-5))
+        @test ishalfodd(5//2)
+        @test ishalfodd(-3//2)
+        @test !ishalfodd(4//3)
+        @test !ishalfodd(2.0)
+        @test ishalfodd(-7.5)
+        @test !ishalfodd(2.3)
+        @test !ishalfodd(π)
+        @test !ishalfodd(ℯ)
+        @test !ishalfodd(im)
     end
 
     @testset "isinteger" begin
@@ -1708,7 +1708,7 @@ end
     @test onehalf(missing) === onehalf(Missing) === missing
 
     @test ishalfinteger(missing) === missing
-    @test ishalfoddinteger(missing) === missing
+    @test ishalfodd(missing) === missing
 end
 
 include("ranges.jl")


### PR DESCRIPTION
This PR adds a new function `ishalfoddinteger`.

```julia
julia> ishalfoddinteger(3.5)
true
julia> ishalfoddinteger(2)
false
julia> ishalfoddinteger(1//3)
false
```

>Note that halving an integer does not always produce a half-integer; this is only true for [odd integers](https://en.wikipedia.org/wiki/Odd_integer). For this reason, half-integers are also sometimes called half-odd-integers.

https://en.wikipedia.org/wiki/Half-integer