### PR TITLE
Remove unnecessary `@static` macro

### DIFF
--- a/src/HalfIntegers.jl
+++ b/src/HalfIntegers.jl
@@ -44,7 +44,7 @@ HalfInteger(x::BigFloat) = BigHalfInt(x)
 (T::Type{<:Integer})(x::HalfInteger) =
     isinteger(x) ? convert(T, twice(x) >> 1) : throw(InexactError(Symbol(T), T, x))
 (::Type{Bool})(x::HalfInteger) = invoke(Bool, Tuple{Real}, x)
-@static if VERSION ≥ v"1.5.0-DEV.820"
+if VERSION ≥ v"1.5.0-DEV.820"
     function (::Type{Rational})(x::HalfInteger)
         tx = twice(x)
         if isinteger(x)
@@ -93,7 +93,7 @@ Base.://(x::Real, y::HalfInteger) = twice(x)//twice(y)
 Base.:^(x::Real, y::HalfInteger) = x^float(y)
 Base.:^(::Irrational{:ℯ}, x::HalfInteger) = exp(x)
 
-@static if VERSION < v"1.4.0-DEV.208"
+if VERSION < v"1.4.0-DEV.208"
     Base.div(x::T, y::T) where T<:HalfInteger = div(twice(x), twice(y))
 else
     Base.div(x::T, y::T, r::RoundingMode) where T<:HalfInteger = div(twice(x), twice(y), r)
@@ -141,7 +141,7 @@ end
 Base.Checked.mul_with_overflow(x::Integer, y::HalfInteger) = Base.Checked.mul_with_overflow(y, x)
 
 # `lcm`/`gcd`/`gcdx` are only extended to `HalfInteger`s if they are defined for `Rational`s
-@static if VERSION ≥ v"1.4.0-DEV.699"
+if VERSION ≥ v"1.4.0-DEV.699"
     Base.gcd(x::HalfInteger) = x
     Base.lcm(x::HalfInteger) = x
 
@@ -186,7 +186,7 @@ Base.isfinite(x::HalfInteger) = isfinite(twice(x))
 
 Base.isinteger(x::HalfInteger) = iseven(twice(x))
 
-@static if VERSION ≥ v"1.6.0-DEV.999"
+if VERSION ≥ v"1.6.0-DEV.999"
     Base.ispow2(x::HalfInteger) = ispow2(twice(x))
 end
 
@@ -257,7 +257,7 @@ function coschalf(x::Integer)
     end
 end
 
-@static if VERSION ≥ v"1.6.0-DEV.292"
+if VERSION ≥ v"1.6.0-DEV.292"
     Base.sincospi(x::HalfInteger) = sincospihalf(twice(x))
 
     # Compute sincos(x*π/2)
@@ -362,7 +362,7 @@ half(::Type{Complex{T}}, x::Number) where T<:HalfInteger = Complex(half(T,real(x
 half(::Type{Complex}, x::Number) = Complex(half(real(x)), half(imag(x)))
 
 half(::Missing) = missing
-@static if VERSION ≥ v"1.3"
+if VERSION ≥ v"1.3"
     half(::Type{T}, x) where T>:Missing = half(Base.nonmissingtype_checked(T), x)
 else
     half(::Type{T}, x) where T>:Missing = half(Base.nonmissingtype(T), x)
@@ -399,7 +399,7 @@ julia> twice(HalfInt32(3.0) + HalfInt32(2.5)*im)  # returns a Complex{Int32}
 twice(x) = x + x
 twice(x::Complex) = Complex(twice(real(x)), twice(imag(x)))
 
-@static if VERSION ≥ v"1.5.0-DEV.820"
+if VERSION ≥ v"1.5.0-DEV.820"
     function twice(x::Rational)
         if iseven(x.den)
             Base.unsafe_rational(oftype(x.num+x.num, x.num), x.den >> 1)
@@ -464,7 +464,7 @@ function twice(T::Type{<:Integer}, x::Rational)
     end
 end
 
-@static if VERSION ≥ v"1.3"
+if VERSION ≥ v"1.3"
     twice(::Type{T}, x) where T>:Missing = twice(Base.nonmissingtype_checked(T), x)
 else
     twice(::Type{T}, x) where T>:Missing = twice(Base.nonmissingtype(T), x)
@@ -528,7 +528,7 @@ onehalf(x::Union{Number,Missing}) = onehalf(typeof(x))
 onehalf(T::Type{<:Number}) = convert(T, onehalf(HalfInteger))
 onehalf(T::Type{<:HalfInteger}) = half(T, 1)
 onehalf(T::Type{<:AbstractFloat}) = convert(T, 0.5)
-@static if VERSION ≥ v"1.5.0-DEV.820"
+if VERSION ≥ v"1.5.0-DEV.820"
     onehalf(::Type{Rational}) = Base.unsafe_rational(1, 2)
     onehalf(::Type{Rational{T}}) where T = Base.unsafe_rational(T, 1, 2)
 else
@@ -561,7 +561,7 @@ ishalfinteger(::HalfIntegerOrInteger) = true
 ishalfinteger(::AbstractIrrational) = false
 ishalfinteger(::Missing) = missing
 
-@static if VERSION ≥ v"1.7.0-DEV.263"
+if VERSION ≥ v"1.7.0-DEV.263"
     Base.range_start_stop_length(start::T, stop::T, len::Integer) where T<:HalfInteger =
         Base._linspace(float(T), start, stop, len)
 else

--- a/test/checked.jl
+++ b/test/checked.jl
@@ -183,7 +183,7 @@
         @test mul_with_overflow(HalfInt8(101/2), Int8(2)) ==ₜ (HalfInt8(-27), true)
     end
 
-    @static if VERSION ≥ v"1.1"
+    if VERSION ≥ v"1.1"
         # In Julia < 1.1, zero(Half{T}) and one(Half{T}) do not work for
         # T ∈ [SafeInt8, SafeInt16, SafeUInt8, SafeUInt16] due to a bug in Julia, cf.
         # https://github.com/JuliaLang/julia/issues/32203

--- a/test/customtypes.jl
+++ b/test/customtypes.jl
@@ -93,7 +93,7 @@ Base.convert(::Type{One}, x::Int) = x == 1 ? One() : error("can't convert $x to 
                  typemin(HalfInt)+HalfInt(1), typemin(HalfInt)+HalfInt(3/2)]
             @test sinpi(MyHalfInt(x)) === sinpi(x)
             @test cospi(MyHalfInt(x)) === cospi(x)
-            @static if VERSION ≥ v"1.6.0-DEV.292"
+            if VERSION ≥ v"1.6.0-DEV.292"
                 @test sincospi(MyHalfInt(x)) === sincospi(x)
             end
         end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -168,7 +168,7 @@ const StepRangeOrStepRangeLen{T} = Union{StepRange{T}, StepRangeLen{T}}
                 @eval @test @inferred(range($T(1/2), length=Int8(5))) isa UnitRange{$T}
             end
             @eval @test range($T(1/2), length=Int8(5)) == $T[1/2, 3/2, 5/2, 7/2, 9/2]
-            @static if VERSION ≥ v"1.7"
+            if VERSION ≥ v"1.7"
                 if VERSION ≥ v"1.8.0-DEV"
                     @eval @test @inferred(range(stop=$T(11/2), length=Int8(5))) isa StepRangeLen{$T,$T,$T}
                 else
@@ -220,7 +220,7 @@ const StepRangeOrStepRangeLen{T} = Union{StepRange{T}, StepRangeLen{T}}
             else
                 @eval @test_broken @inferred(range($T(1/2), step=big(2), length=Int8(5))) isa StepRangeOrStepRangeLen{BigHalfInt}
             end
-            @static if VERSION ≥ v"1.7.0-DEV.16"
+            if VERSION ≥ v"1.7.0-DEV.16"
                 @eval @test @inferred(range(Int8(2), step=$T(1/2), length=Int8(5))) isa StepRangeOrStepRangeLen{$T}
                 @eval @test range(Int8(2), step=$T(1/2), length=Int8(5)) == $T[2, 5/2, 3, 7/2, 4]
             else
@@ -229,7 +229,7 @@ const StepRangeOrStepRangeLen{T} = Union{StepRange{T}, StepRangeLen{T}}
             end
         end
 
-        @static if VERSION ≥ v"1.7.0-DEV.263"
+        if VERSION ≥ v"1.7.0-DEV.263"
             for T in (inttypes..., uinttypes..., :BigInt)
                 @eval @test @inferred(range(stop=Half{$T}(23/2), step=Int8(2), length=$T(5))) isa StepRangeOrStepRangeLen{Half{$T}}
                 @eval @test range(stop=Half{$T}(23/2), step=Int8(2), length=$T(5)) == Half{$T}[7/2, 11/2, 15/2, 19/2, 23/2]
@@ -335,7 +335,7 @@ const StepRangeOrStepRangeLen{T} = Union{StepRange{T}, StepRangeLen{T}}
             @eval @test (1:3:7) ∩ ($T(3):$T(5)) == 4:3:4
             @eval @test ($T(3):$T(5)) ∩ (1:3:7) == 4:3:4
         end
-        @static if Sys.WORD_SIZE == 64
+        if Sys.WORD_SIZE == 64
             @test isempty((1:3:7) ∩ (HalfUInt32(3/2):HalfUInt32(5)))
             @test isempty((HalfUInt32(3/2):HalfUInt32(5)) ∩ (1:3:7))
             @test (1:3:7) ∩ (HalfUInt32(3):HalfUInt32(5)) == 4:3:4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -387,7 +387,7 @@ end
         end
     end
 
-    @static if VERSION ≥ v"1.6.0-DEV.999"
+    if VERSION ≥ v"1.6.0-DEV.999"
         @testset "ispow2" begin
             for T in (halfinttypes..., :BigHalfInt)
                 @eval @test ispow2($T(1/2))
@@ -812,7 +812,7 @@ end
             @eval @test @inferred(rem(big(4), BigHalfInt(3/2), $r)) isa BigHalfInt
             @eval @test @inferred(rem(big(4), HalfInt(3/2), $r)) isa BigHalfInt
         end
-        @static if VERSION ≥ v"1.4.0-DEV.208"
+        if VERSION ≥ v"1.4.0-DEV.208"
             for r in (:RoundNearest, :RoundNearestTiesAway, :RoundNearestTiesUp, :RoundToZero, :RoundUp, :RoundDown)
                 for T in (halfinttypes..., halfuinttypes..., :BigHalfInt)
                     @eval @test @inferred(div($T(7/2), $T(3/2), $r)) == div(7//2, 3//2, $r)
@@ -868,7 +868,7 @@ end
                 @eval @test @inferred(divrem(big(4), HalfInt(3/2), $r)) isa Tuple{BigInt,BigHalfInt}
             end
         end
-        @static if VERSION ≥ v"1.5.0-DEV.471"
+        if VERSION ≥ v"1.5.0-DEV.471"
             for (f,bigreturntype) in ((:rem, :BigHalfInt), (:divrem, :(Tuple{BigInt,BigHalfInt})))
                 for T in (halfinttypes..., :BigHalfInt)
                     @eval @test @inferred($f($T(7/2), $T(3/2), RoundNearest)) == $f(7//2, 3//2, RoundNearest)
@@ -1046,7 +1046,7 @@ end
         @test complex(BigHalfInt(-2))^HalfInt(5/2) ≈ √32*im
     end
 
-    @static if VERSION ≥ v"1.4.0-DEV.699"
+    if VERSION ≥ v"1.4.0-DEV.699"
         @testset "lcm/gcd/gcdx" begin
             @testset "Scalar-argument gcd/lcm" begin
                 for T in (halfinttypes..., halfuinttypes..., :BigHalfInt)
@@ -1532,7 +1532,7 @@ end
     for T = (inttypes..., uinttypes..., :BigInt)
         @eval @test typeof(@inferred(sinpi(zero(Half{$T})))) == float(Half{$T})
         @eval @test typeof(@inferred(cospi(zero(Half{$T})))) == float(Half{$T})
-        @static if isdefined(Base, :sincospi)
+        if isdefined(Base, :sincospi)
             @eval @test typeof(@inferred(sincospi(zero(Half{$T})))) == NTuple{2, float(Half{$T})}
         end
     end


### PR DESCRIPTION
As commented in https://github.com/sostock/HalfIntegers.jl/pull/59#discussion_r1412104141, we don't need `@static` macro outside of functions. This PR removes the unnecessary `@static` macro uses.